### PR TITLE
Resolved an issue with multiple "connect" calls

### DIFF
--- a/electron/golem_handler.js
+++ b/electron/golem_handler.js
@@ -55,13 +55,14 @@ class GolemProcess {
         /* Handle process events */
         this.process.on('error', data => {
             console.error('💻 Cannot start Golem:', data.toString())
-        })
+        });
         this.process.on('exit', code => {
             console.log('💻 Golem exited with code', code);
         });
+        /* FIXME: we shouldn't be catching stdout here.
         this.process.stderr.on('data', data => {
             console.error('💻 Golem error:', data.toString());
-        });
+        });*/
     }
 
     stopProcess() {
@@ -76,9 +77,6 @@ class GolemProcess {
 function golemHandler(app) {
     app.golem = new GolemProcess();
 
-    app.on('window-all-closed', () => {
-        app.golem.stopProcess();
-    });
     ipcMain.on('start-golem-process', () => {
         app.golem.startProcess();
     });

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ app.on('ready', onReady)
 
 app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {
+        app.golem.stopProcess();
         app.quit()
     }
 })

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -42,6 +42,7 @@ export function connect() {
          * @return {[Object]}       connection          ['Connection with session']
          */
         function connect() {
+            let connectTimeout = null;
             let connection = new Wampy(config.WS_URL,
                 {
                     realm: config.REALM,
@@ -54,10 +55,17 @@ export function connect() {
                             connection
                         });
                     },
+                    onClose: function () {
+                        console.log('Wampy connection was closed.');
+                    },
                     onError: (err, details) => {
-                        console.info('Wampy connection error', err, details);
+                        console.info('Wampy connection error:', err, details);
+                        if (connectTimeout) return;
+
+                        console.info('Wampy is connecting');
                         ipcRenderer.send('start-golem-process');
-                        setTimeout(() => {
+                        connectTimeout = setTimeout(() => {
+                            connectTimeout = null;
                             connect();
                         }, 5000) //can be less
                     }


### PR DESCRIPTION
Plus:
- stderr logging disabled, which was receiving output from stdout
- does not kill Golem's process when closing the window on macOS