### PR TITLE
Specify core rpc port

### DIFF
--- a/electron/golem_handler.js
+++ b/electron/golem_handler.js
@@ -14,7 +14,7 @@ class GolemProcess {
     constructor(processName, processArgs) {
         this.process = null;
         this.processName = processName || 'golemapp';
-        this.processArgs = processArgs || ['--nogui'];
+        this.processArgs = processArgs || ['--nogui', '-r', '0.0.0.0:61000'];
     }
 
     startProcess(err, pid) {

--- a/electron/golem_handler.js
+++ b/electron/golem_handler.js
@@ -14,7 +14,7 @@ class GolemProcess {
     constructor(processName, processArgs) {
         this.process = null;
         this.processName = processName || 'golemapp';
-        this.processArgs = processArgs || ['--nogui', '-r', '0.0.0.0:61000'];
+        this.processArgs = processArgs || ['--nogui', '-r', '127.0.0.1:61000'];
     }
 
     startProcess(err, pid) {


### PR DESCRIPTION
When _golem core_ has non standard port in settings it won't connect with frontend. That's why it needs to be specified in spawn invocation.