### PR TITLE
gui hardware preset fx

### DIFF
--- a/src/components/RadialProgress.js
+++ b/src/components/RadialProgress.js
@@ -12,7 +12,7 @@ export default class RadialProgress extends React.Component {
     }
 
     render() {
-        const {pct, title, max, warn, disabled} = this.props
+        const {pct, title, unit, max, warn, disabled} = this.props
         let maximum = max || 100
         let ratio = ((pct <= maximum ? pct : maximum) / maximum).toFixed(2)
         let color;
@@ -30,7 +30,7 @@ export default class RadialProgress extends React.Component {
             'stroke': color
         });
         return (
-            <div className="radial-progress-bar" data-title={title ? title : `${(100 * (pct / maximum)).toFixed(0)}%`}>
+            <div className="radial-progress-bar" data-title={title ? title : `${(100 * (pct / maximum)).toFixed(0)}%`} data-unit={unit ? unit : title}>
                 <svg id="radialSvg" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110 110" preserveAspectRatio="xMinYMin meet">
                     <circle r="47.25" cx="52.5" cy="52.5" fill="transparent" strokeDasharray="500" strokeDashoffset="0"></circle>
                     <circle id="bar" r="47.25" cx="52.5" cy="52.5" fill="transparent" strokeDasharray="500" strokeDashoffset="0" style={style}></circle>

--- a/src/components/network/modal/PresetModal.js
+++ b/src/components/network/modal/PresetModal.js
@@ -60,11 +60,11 @@ export default class PresetModal extends React.Component {
                         </div>
                         <div>
                             <h5>RAM</h5>
-                            <span>{(memory / 1024000).toFixed(0)} GB</span>
+                            <span>{(memory / 1048576).toFixed(1)} GiB</span>
                         </div>
                         <div>
                             <h5>Disk</h5>
-                            <span>{(disk / 1024000).toFixed(0)} GB</span>
+                            <span>{(disk / 1048576).toFixed(1)} GiB</span>
                         </div>
                     </section>
                     <div className="action__modal">

--- a/src/components/network/modal/PresetModal.js
+++ b/src/components/network/modal/PresetModal.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const mebi = 1 << 20
+
 export default class PresetModal extends React.Component {
 
 
@@ -35,11 +37,13 @@ export default class PresetModal extends React.Component {
         e.preventDefault();
         const {saveCallback, cpu_cores, memory, disk} = this.props
         const {name} = this.state
+        let memoryKiB = memory * mebi
+        let diskKiB = disk * mebi
         saveCallback({
             name,
             cpu_cores,
-            memory,
-            disk
+            memory: memoryKiB,
+            disk: diskKiB
         })
         this.props.closeModal()
     }
@@ -60,11 +64,11 @@ export default class PresetModal extends React.Component {
                         </div>
                         <div>
                             <h5>RAM</h5>
-                            <span>{(memory / 1048576).toFixed(1)} GiB</span>
+                            <span>{memory} GiB</span>
                         </div>
                         <div>
                             <h5>Disk</h5>
-                            <span>{(disk / 1048576).toFixed(1)} GiB</span>
+                            <span>{disk} GiB</span>
                         </div>
                     </section>
                     <div className="action__modal">

--- a/src/components/network/tabs/Advanced.js
+++ b/src/components/network/tabs/Advanced.js
@@ -9,7 +9,13 @@ import Dropdown from './../../Dropdown'
 const mockSystemInfo = {
     num_cores: 3,
     max_memory_size: 3145728,
-    max_resource_size: 10240000
+    max_resource_size: 10 * 1048576
+}
+
+const min = {
+    cpu_cores: 1,
+    memory: 1048576,
+    disk: 1048576
 }
 
 const preset = Object.freeze({
@@ -84,9 +90,9 @@ export class Advanced extends React.Component {
      */
     calculateResourceValue({cpu_cores, memory, disk}) {
         const {systemInfo} = this.props
-        let cpuRatio = (this.maxVal(cpu_cores, systemInfo.cpu_cores) / systemInfo.cpu_cores)
-        let ramRatio = (this.maxVal(memory, systemInfo.memory) / systemInfo.memory)
-        let diskRatio = (this.maxVal(disk, systemInfo.disk) / systemInfo.disk)
+        let cpuRatio = (this.clampResource(cpu_cores, systemInfo, 'cpu_cores') / systemInfo.cpu_cores)
+        let ramRatio = (this.clampResource(memory, systemInfo, 'memory') / systemInfo.memory)
+        let diskRatio = (this.clampResource(disk, systemInfo, 'disk') / systemInfo.disk)
         return 100 * ((cpuRatio + ramRatio + diskRatio) / 3)
     }
 
@@ -108,14 +114,18 @@ export class Advanced extends React.Component {
     }
 
     /**
-     * [maxVal check the max limit for the resources]
+     * [clampResource returns a value limited to given resource name bounds]
+     *
      * @param  {Number} val   [Given resource value]
-     * @param  {Number} limit [Max limit for the given resource value]
-     * @return {Number}       [Min value of between]
+     * @param  {Object} upper [Object with upper bounds]
+     * @param  {String} name  [Name of the resource]
+     * @return {Number}       [A number in the range [min, systemInfo]]
+     *
+     * @credit https://stackoverflow.com/a/11409944/3805131
      */
-    maxVal(val, limit) {
-        return Math.min(val, limit)
-    }
+    clampResource(val, upper, name) {
+        return Math.min(Math.max(this, min[name]), upper[name]);
+    };
 
     render() {
         const {presetList, chosenPreset, manageHandler, systemInfo, chartValues, isEngineOn} = this.props
@@ -133,15 +143,15 @@ export class Advanced extends React.Component {
             <div className="section__radial-options">
               <div className="item__radial-options">
                 <RadialProgress pct={cpu_cores} title="CPU" max={systemInfo.cpu_cores} warn={true} disabled={isEngineOn}/>
-                <input type="number" min="0" step="1" max={systemInfo.cpu_cores} onChange={this._handleInputChange.bind(this, 'cpu_cores')} value={this.maxVal(cpu_cores, systemInfo.cpu_cores)} disabled={isEngineOn}/>
+                <input type="number" min={min.cpu_cores} step="1" max={systemInfo.cpu_cores} onChange={this._handleInputChange.bind(this, 'cpu_cores')} value={this.clampResource(cpu_cores, systemInfo, 'cpu_cores')} disabled={isEngineOn}/>
               </div>
               <div className="item__radial-options">
                 <RadialProgress pct={memory} title="RAM" max={systemInfo.memory} warn={true} disabled={isEngineOn}/>
-                <input type="number" min="0" step="128" max={systemInfo.memory} onChange={this._handleInputChange.bind(this, 'memory')} value={this.maxVal(memory, systemInfo.memory)} disabled={isEngineOn}/>
+                <input type="number" min={min.memory} step="1024" max={systemInfo.memory} onChange={this._handleInputChange.bind(this, 'memory')} value={this.clampResource(memory, systemInfo, 'memory')} disabled={isEngineOn}/>
               </div>
               <div className="item__radial-options">
                 <RadialProgress pct={disk} title="Disk" max={systemInfo.disk} warn={true} disabled={isEngineOn}/>
-                <input type="number" min="0" step="1" max={systemInfo.disk} onChange={this._handleInputChange.bind(this, 'disk')} value={this.maxVal(disk, systemInfo.disk)} disabled={isEngineOn}/>
+                <input type="number" min={min.disk} step="1024" max={systemInfo.disk} onChange={this._handleInputChange.bind(this, 'disk')} value={this.clampResource(disk, systemInfo, 'disk')} disabled={isEngineOn}/>
               </div>
             </div>
             <div className="advanced__tips">

--- a/src/components/network/tabs/Advanced.js
+++ b/src/components/network/tabs/Advanced.js
@@ -14,8 +14,8 @@ const mockSystemInfo = {
 
 const min = {
     cpu_cores: 1,
-    memory: 1048576,
-    disk: 1048576
+    memory: 1024,
+    disk: 1024
 }
 
 const preset = Object.freeze({
@@ -90,9 +90,9 @@ export class Advanced extends React.Component {
      */
     calculateResourceValue({cpu_cores, memory, disk}) {
         const {systemInfo} = this.props
-        let cpuRatio = (this.clampResource(cpu_cores, systemInfo, 'cpu_cores') / systemInfo.cpu_cores)
-        let ramRatio = (this.clampResource(memory, systemInfo, 'memory') / systemInfo.memory)
-        let diskRatio = (this.clampResource(disk, systemInfo, 'disk') / systemInfo.disk)
+        let cpuRatio = (this.maxVal(cpu_cores, systemInfo.cpu_cores) / systemInfo.cpu_cores)
+        let ramRatio = (this.maxVal(memory, systemInfo.memory) / systemInfo.memory)
+        let diskRatio = (this.maxVal(disk, systemInfo.disk) / systemInfo.disk)
         return 100 * ((cpuRatio + ramRatio + diskRatio) / 3)
     }
 
@@ -114,18 +114,14 @@ export class Advanced extends React.Component {
     }
 
     /**
-     * [clampResource returns a value limited to given resource name bounds]
-     *
+     * [maxVal check the max limit for the resources]
      * @param  {Number} val   [Given resource value]
-     * @param  {Object} upper [Object with upper bounds]
-     * @param  {String} name  [Name of the resource]
-     * @return {Number}       [A number in the range [min, systemInfo]]
-     *
-     * @credit https://stackoverflow.com/a/11409944/3805131
+     * @param  {Number} limit [Max limit for the given resource value]
+     * @return {Number}       [Min value of between]
      */
-    clampResource(val, upper, name) {
-        return Math.min(Math.max(this, min[name]), upper[name]);
-    };
+    maxVal(val, limit) {
+        return Math.min(val, limit)
+    }
 
     render() {
         const {presetList, chosenPreset, manageHandler, systemInfo, chartValues, isEngineOn} = this.props
@@ -143,15 +139,15 @@ export class Advanced extends React.Component {
             <div className="section__radial-options">
               <div className="item__radial-options">
                 <RadialProgress pct={cpu_cores} title="CPU" max={systemInfo.cpu_cores} warn={true} disabled={isEngineOn}/>
-                <input type="number" min={min.cpu_cores} step="1" max={systemInfo.cpu_cores} onChange={this._handleInputChange.bind(this, 'cpu_cores')} value={this.clampResource(cpu_cores, systemInfo, 'cpu_cores')} disabled={isEngineOn}/>
+                <input type="number" min={min.cpu_cores} step={min.cpu_cores} max={systemInfo.cpu_cores} onChange={this._handleInputChange.bind(this, 'cpu_cores')} value={this.maxVal(cpu_cores, systemInfo.cpu_cores)} disabled={isEngineOn}/>
               </div>
               <div className="item__radial-options">
                 <RadialProgress pct={memory} title="RAM" max={systemInfo.memory} warn={true} disabled={isEngineOn}/>
-                <input type="number" min={min.memory} step="1024" max={systemInfo.memory} onChange={this._handleInputChange.bind(this, 'memory')} value={this.clampResource(memory, systemInfo, 'memory')} disabled={isEngineOn}/>
+                <input type="number" min={min.memory} step={min.memory} max={systemInfo.memory} onChange={this._handleInputChange.bind(this, 'memory')} value={this.maxVal(memory, systemInfo.memory)} disabled={isEngineOn}/>
               </div>
               <div className="item__radial-options">
                 <RadialProgress pct={disk} title="Disk" max={systemInfo.disk} warn={true} disabled={isEngineOn}/>
-                <input type="number" min={min.disk} step="1024" max={systemInfo.disk} onChange={this._handleInputChange.bind(this, 'disk')} value={this.clampResource(disk, systemInfo, 'disk')} disabled={isEngineOn}/>
+                <input type="number" min={min.disk} step={min.disk} max={systemInfo.disk} onChange={this._handleInputChange.bind(this, 'disk')} value={this.maxVal(disk, systemInfo.disk)} disabled={isEngineOn}/>
               </div>
             </div>
             <div className="advanced__tips">

--- a/src/scss/radial-progress.scss
+++ b/src/scss/radial-progress.scss
@@ -38,4 +38,7 @@
         font-size: .8em;
         font-weight: 500;
     }
+    &:hover:after {
+        content: attr(data-unit);
+    }
 }


### PR DESCRIPTION
resolves #251 

We use GiB (2^30) instead of some undefined mix 1000 * 1024 which is nor GB nor GiB.
Besides this change introduces minimal values for presets with checking function and new step values.

See also golemfactory/golem#2445