### PR TITLE
Applying default file preset fix

### DIFF
--- a/src/components/tasks/TaskDetail.js
+++ b/src/components/tasks/TaskDetail.js
@@ -675,7 +675,7 @@ export class TaskDetail extends React.Component {
 
         this.setState({
             resolution,
-            format,
+            format: formatRef.value,
             formatIndex,
             isDefaultResolutionApplied: true
         })


### PR DESCRIPTION
While applying default file preset, formatRev evaluated as format value to prevent unknown file extensions.