### PR TITLE
Web3 Dependency Removal

### DIFF
--- a/electron/eth_checksum.js
+++ b/electron/eth_checksum.js
@@ -1,6 +1,5 @@
-const Web3 = require('web3');
+const web3Utils = require('web3-utils');
 
 module.exports = async function toChecksumAddress(address) {
-	const web3 = new Web3();
-	return await web3.utils.toChecksumAddress(address)
+	return await web3Utils.toChecksumAddress(address)
 }

--- a/electron/geth_validator.js
+++ b/electron/geth_validator.js
@@ -1,11 +1,11 @@
-const Web3 = require('web3');
+const Web3Net = require('web3-net');
 const axios = require('axios');
+const getNetworkType = require('../src/utils/getNetworkType');
 
 
 module.exports = async function validateGeth(isLocalGeth, gethAddress, gethPort, isMainnet) {
 	const gethURL = `${isLocalGeth ? "http://localhost" : gethAddress}${isLocalGeth ? ":" + (gethPort || 8545) : ""}`
-	const web3Provider = new Web3.providers.HttpProvider(gethURL)
-	const web3 = new Web3(web3Provider);
+	const web3Net = new Web3Net(gethURL);
 
 	try{
 
@@ -16,9 +16,9 @@ module.exports = async function validateGeth(isLocalGeth, gethAddress, gethPort,
 				headers: {'Content-Type': 'application/json'}
 		});
 
-		const isListening = await web3.eth.net.isListening()
+		const isListening = await web3Net.isListening()
 		if(isListening && isValid){
-		    const guessedChain = await web3.eth.net.getNetworkType()
+		    const guessedChain = await getNetworkType(gethURL, web3Net)
 	        if((guessedChain === "main" && isMainnet) ||
 	            (guessedChain === "rinkeby" && !isMainnet)) {
 	        	return { status: true, error: null }

--- a/package-lock.json
+++ b/package-lock.json
@@ -712,6 +712,7 @@
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
@@ -1940,7 +1941,8 @@
         "base64-js": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-            "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+            "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+            "dev": true
         },
         "batch": {
             "version": "0.6.1",
@@ -1990,6 +1992,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+            "dev": true,
             "requires": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -1998,12 +2001,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
                 },
                 "readable-stream": {
                     "version": "2.3.5",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
                     "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -2018,6 +2023,7 @@
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -2028,6 +2034,7 @@
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
             "requires": {
                 "inherits": "~2.0.0"
             }
@@ -2035,7 +2042,8 @@
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+            "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+            "dev": true
         },
         "bluebird-lst": {
             "version": "1.0.5",
@@ -2152,6 +2160,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2160,7 +2169,8 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true
                 }
             }
         },
@@ -2199,6 +2209,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
             "requires": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -2212,6 +2223,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
             "requires": {
                 "browserify-aes": "^1.0.4",
                 "browserify-des": "^1.0.0",
@@ -2222,6 +2234,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.1",
                 "des.js": "^1.0.0",
@@ -2232,6 +2245,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "randombytes": "^2.0.1"
@@ -2249,6 +2263,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.1",
                 "browserify-rsa": "^4.0.0",
@@ -2306,30 +2321,6 @@
                 }
             }
         },
-        "buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-        },
-        "buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
-        },
         "buffer-from": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
@@ -2350,7 +2341,8 @@
         "buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
         },
         "builder-util": {
             "version": "5.16.0",
@@ -2820,6 +2812,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -3111,7 +3104,8 @@
         "commander": {
             "version": "2.14.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-            "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+            "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -3187,7 +3181,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.6.2",
@@ -3365,6 +3360,11 @@
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
+        "cookiejar": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+            "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+        },
         "copy-concurrently": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -3409,6 +3409,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "elliptic": "^6.0.0"
@@ -3427,6 +3428,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -3439,6 +3441,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -3485,6 +3488,7 @@
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
             "requires": {
                 "browserify-cipher": "^1.0.0",
                 "browserify-sign": "^4.0.0",
@@ -3740,122 +3744,12 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
-        "decompress": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-            "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-            "requires": {
-                "decompress-tar": "^4.0.0",
-                "decompress-tarbz2": "^4.0.0",
-                "decompress-targz": "^4.0.0",
-                "decompress-unzip": "^4.0.1",
-                "graceful-fs": "^4.1.10",
-                "make-dir": "^1.0.0",
-                "pify": "^2.3.0",
-                "strip-dirs": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                }
-            }
-        },
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "requires": {
                 "mimic-response": "^1.0.0"
-            }
-        },
-        "decompress-tar": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-            "requires": {
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0",
-                "tar-stream": "^1.5.2"
-            }
-        },
-        "decompress-tarbz2": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-            "requires": {
-                "decompress-tar": "^4.1.0",
-                "file-type": "^6.1.0",
-                "is-stream": "^1.1.0",
-                "seek-bzip": "^1.0.5",
-                "unbzip2-stream": "^1.0.9"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
-                }
-            }
-        },
-        "decompress-targz": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-            "requires": {
-                "decompress-tar": "^4.1.1",
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0"
-            }
-        },
-        "decompress-unzip": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-            "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-            "requires": {
-                "file-type": "^3.8.0",
-                "get-stream": "^2.2.0",
-                "pify": "^2.3.0",
-                "yauzl": "^2.4.2"
-            },
-            "dependencies": {
-                "fd-slicer": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-                    "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-                    "requires": {
-                        "pend": "~1.2.0"
-                    }
-                },
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-                },
-                "get-stream": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-                    "requires": {
-                        "object-assign": "^4.0.1",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-                },
-                "yauzl": {
-                    "version": "2.10.0",
-                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-                    "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-                    "requires": {
-                        "buffer-crc32": "~0.2.3",
-                        "fd-slicer": "~1.1.0"
-                    }
-                }
             }
         },
         "deep-equal": {
@@ -3987,6 +3881,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
@@ -4028,6 +3923,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
@@ -4292,7 +4188,8 @@
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
         },
         "duplexify": {
             "version": "3.6.0",
@@ -4848,6 +4745,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -5184,6 +5082,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
             "requires": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
@@ -5469,11 +5368,6 @@
             "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==",
             "dev": true
         },
-        "file-type": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-            "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-        },
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -5705,11 +5599,6 @@
                 "readable-stream": "^2.0.0"
             }
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-        },
         "fs-extra": {
             "version": "0.30.0",
             "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -5757,36 +5646,6 @@
                 }
             }
         },
-        "fs-promise": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
-            "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
-            "requires": {
-                "any-promise": "^1.3.0",
-                "fs-extra": "^2.0.0",
-                "mz": "^2.6.0",
-                "thenify-all": "^1.6.0"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                }
-            }
-        },
         "fs-write-stream-atomic": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -5802,7 +5661,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "1.2.4",
@@ -6350,6 +6210,7 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -6455,6 +6316,7 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6577,11 +6439,6 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-        },
         "growly": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -6697,24 +6554,11 @@
             "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
             "dev": true
         },
-        "has-symbol-support-x": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-        },
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
             "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
             "dev": true
-        },
-        "has-to-string-tag-x": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-            "requires": {
-                "has-symbol-support-x": "^1.4.1"
-            }
         },
         "has-unicode": {
             "version": "2.0.1",
@@ -6778,6 +6622,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -7386,7 +7231,8 @@
         "ieee754": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+            "dev": true
         },
         "iferr": {
             "version": "0.1.5",
@@ -7452,6 +7298,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -7779,11 +7626,6 @@
                 "is-path-inside": "^1.0.0"
             }
         },
-        "is-natural-number": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-            "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
-        },
         "is-npm": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -7809,11 +7651,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-        },
-        "is-object": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
         },
         "is-odd": {
             "version": "2.0.0",
@@ -7859,7 +7696,8 @@
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -7906,7 +7744,8 @@
         "is-retry-allowed": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "dev": true
         },
         "is-stream": {
             "version": "1.1.0",
@@ -8066,15 +7905,6 @@
             "dev": true,
             "requires": {
                 "handlebars": "^4.0.3"
-            }
-        },
-        "isurl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-            "requires": {
-                "has-to-string-tag-x": "^1.2.0",
-                "is-object": "^1.0.1"
             }
         },
         "jest": {
@@ -9246,7 +9076,8 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+            "dev": true
         },
         "lru-cache": {
             "version": "4.1.1",
@@ -9332,6 +9163,7 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -9429,6 +9261,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "brorand": "^1.0.1"
@@ -9485,6 +9318,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -9579,19 +9413,6 @@
                 }
             }
         },
-        "mkdirp-promise": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
-            "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
-            "requires": {
-                "mkdirp": "*"
-            }
-        },
-        "mock-fs": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
-            "integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w=="
-        },
         "mock-socket": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-6.1.0.tgz",
@@ -9615,11 +9436,6 @@
             "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
             "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
             "dev": true
-        },
-        "mout": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-            "integrity": "sha1-ujYR318OWx/7/QEWa48C0fX6K5k="
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -9673,16 +9489,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
-        },
-        "mz": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-            "requires": {
-                "any-promise": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "thenify-all": "^1.0.0"
-            }
         },
         "nan": {
             "version": "2.8.0",
@@ -10429,11 +10235,6 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
-        "p-cancelable": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-        },
         "p-defer": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -10470,14 +10271,6 @@
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "dev": true
-        },
-        "p-timeout": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-            "requires": {
-                "p-finally": "^1.0.0"
-            }
         },
         "p-try": {
             "version": "1.0.0",
@@ -10526,6 +10319,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+            "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
                 "browserify-aes": "^1.0.0",
@@ -10625,7 +10419,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -10672,6 +10467,7 @@
             "version": "3.0.16",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+            "dev": true,
             "requires": {
                 "create-hash": "^1.1.2",
                 "create-hmac": "^1.1.4",
@@ -10683,7 +10479,8 @@
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -10699,12 +10496,14 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -11424,7 +11223,8 @@
         "prepend-http": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
         },
         "preserve": {
             "version": "0.2.0",
@@ -11493,7 +11293,8 @@
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
         },
         "progress-stream": {
             "version": "1.2.0",
@@ -11568,6 +11369,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "browserify-rsa": "^4.0.0",
@@ -11676,6 +11478,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
             }
@@ -11684,6 +11487,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
             "requires": {
                 "randombytes": "^2.0.5",
                 "safe-buffer": "^5.1.0"
@@ -12120,6 +11924,7 @@
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
             "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -12133,12 +11938,14 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
                 },
                 "string_decoder": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -12632,6 +12439,7 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -12640,6 +12448,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -13146,31 +12955,6 @@
                 }
             }
         },
-        "scrypt": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
-            "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
-            "requires": {
-                "nan": "^2.0.8"
-            }
-        },
-        "scrypt.js": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
-            "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
-            "requires": {
-                "scrypt": "^6.0.2",
-                "scryptsy": "^1.2.1"
-            }
-        },
-        "scryptsy": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
-            "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
-            "requires": {
-                "pbkdf2": "^3.0.3"
-            }
-        },
         "scss-tokenizer": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -13188,24 +12972,6 @@
                     "dev": true,
                     "requires": {
                         "amdefine": ">=0.0.4"
-                    }
-                }
-            }
-        },
-        "seek-bzip": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-            "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-            "requires": {
-                "commander": "~2.8.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-                    "requires": {
-                        "graceful-readlink": ">= 1.0.0"
                     }
                 }
             }
@@ -13353,7 +13119,8 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.1.0",
@@ -13364,6 +13131,7 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -14107,14 +13875,6 @@
                 "is-utf8": "^0.2.0"
             }
         },
-        "strip-dirs": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-            "requires": {
-                "is-natural-number": "^4.0.1"
-            }
-        },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -14243,75 +14003,6 @@
                 }
             }
         },
-        "swarm-js": {
-            "version": "0.1.37",
-            "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
-            "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
-            "requires": {
-                "bluebird": "^3.5.0",
-                "buffer": "^5.0.5",
-                "decompress": "^4.0.0",
-                "eth-lib": "^0.1.26",
-                "fs-extra": "^2.1.2",
-                "fs-promise": "^2.0.0",
-                "got": "^7.1.0",
-                "mime-types": "^2.1.16",
-                "mkdirp-promise": "^5.0.1",
-                "mock-fs": "^4.1.0",
-                "setimmediate": "^1.0.5",
-                "tar.gz": "^1.0.5",
-                "xhr-request-promise": "^0.1.2"
-            },
-            "dependencies": {
-                "buffer": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-                    "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-                    "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
-                    }
-                },
-                "fs-extra": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-                    "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^2.1.0"
-                    }
-                },
-                "got": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                    "requires": {
-                        "decompress-response": "^3.2.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-plain-obj": "^1.1.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "isurl": "^1.0.0-alpha5",
-                        "lowercase-keys": "^1.0.0",
-                        "p-cancelable": "^0.3.0",
-                        "p-timeout": "^1.1.1",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "url-parse-lax": "^1.0.0",
-                        "url-to-options": "^1.0.1"
-                    }
-                },
-                "jsonfile": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                }
-            }
-        },
         "symbol-observable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -14340,43 +14031,11 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
             "requires": {
                 "block-stream": "*",
                 "fstream": "^1.0.2",
                 "inherits": "2"
-            }
-        },
-        "tar-stream": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
-            "requires": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.1.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "tar.gz": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
-            "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
-            "requires": {
-                "bluebird": "^2.9.34",
-                "commander": "^2.8.1",
-                "fstream": "^1.0.8",
-                "mout": "^0.11.0",
-                "tar": "^2.1.1"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                    "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-                }
             }
         },
         "temp-file": {
@@ -14665,22 +14324,6 @@
                 }
             }
         },
-        "thenify": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-            "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-            "requires": {
-                "any-promise": "^1.0.0"
-            }
-        },
-        "thenify-all": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-            "requires": {
-                "thenify": ">= 3.1.0 < 4"
-            }
-        },
         "throat": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -14696,7 +14339,8 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
         },
         "through2": {
             "version": "0.2.3",
@@ -14787,11 +14431,6 @@
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
-        },
-        "to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
         },
         "to-fast-properties": {
             "version": "1.0.3",
@@ -15100,37 +14739,6 @@
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
         },
-        "unbzip2-stream": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-            "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
-            "requires": {
-                "buffer": "^3.0.1",
-                "through": "^2.3.6"
-            },
-            "dependencies": {
-                "base64-js": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-                    "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
-                },
-                "buffer": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
-                    "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
-                    "requires": {
-                        "base64-js": "0.0.8",
-                        "ieee754": "^1.1.4",
-                        "isarray": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                }
-            }
-        },
         "underscore": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
@@ -15405,6 +15013,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "dev": true,
             "requires": {
                 "prepend-http": "^1.0.1"
             }
@@ -15413,11 +15022,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
             "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
-        },
-        "url-to-options": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-            "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
         },
         "use": {
             "version": "3.1.0",
@@ -15467,7 +15071,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "util-inspect": {
             "version": "0.1.8",
@@ -16013,342 +15618,145 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
-        "web3": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
-            "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
-            "requires": {
-                "web3-bzz": "1.0.0-beta.34",
-                "web3-core": "1.0.0-beta.34",
-                "web3-eth": "1.0.0-beta.34",
-                "web3-eth-personal": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34",
-                "web3-shh": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
-        "web3-bzz": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
-            "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
-            "requires": {
-                "got": "7.1.0",
-                "swarm-js": "0.1.37",
-                "underscore": "1.8.3"
-            },
-            "dependencies": {
-                "got": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                    "requires": {
-                        "decompress-response": "^3.2.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-plain-obj": "^1.1.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "isurl": "^1.0.0-alpha5",
-                        "lowercase-keys": "^1.0.0",
-                        "p-cancelable": "^0.3.0",
-                        "p-timeout": "^1.1.1",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "url-parse-lax": "^1.0.0",
-                        "url-to-options": "^1.0.1"
-                    }
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-core": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
-            "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
-            "requires": {
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-requestmanager": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
-        "web3-core-helpers": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
-            "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-eth-iban": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-core-method": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
-            "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-promievent": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-core-promievent": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
-            "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
-            "requires": {
-                "any-promise": "1.3.0",
-                "eventemitter3": "1.1.1"
-            }
-        },
-        "web3-core-requestmanager": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
-            "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-providers-http": "1.0.0-beta.34",
-                "web3-providers-ipc": "1.0.0-beta.34",
-                "web3-providers-ws": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-core-subscriptions": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
-            "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
-            "requires": {
-                "eventemitter3": "1.1.1",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-eth": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
-            "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-eth-abi": "1.0.0-beta.34",
-                "web3-eth-accounts": "1.0.0-beta.34",
-                "web3-eth-contract": "1.0.0-beta.34",
-                "web3-eth-iban": "1.0.0-beta.34",
-                "web3-eth-personal": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-eth-abi": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
-            "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
-            "requires": {
-                "bn.js": "4.11.6",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.6",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-eth-accounts": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
-            "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
-            "requires": {
-                "any-promise": "1.3.0",
-                "crypto-browserify": "3.12.0",
-                "eth-lib": "0.2.7",
-                "scrypt.js": "0.2.0",
-                "underscore": "1.8.3",
-                "uuid": "2.0.1",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-                    "requires": {
-                        "bn.js": "^4.11.6",
-                        "elliptic": "^6.4.0",
-                        "xhr-request-promise": "^0.1.2"
-                    }
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                },
-                "uuid": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-                    "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-                }
-            }
-        },
-        "web3-eth-contract": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
-            "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-promievent": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-eth-abi": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-eth-iban": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
-            "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
-            "requires": {
-                "bn.js": "4.11.6",
-                "web3-utils": "1.0.0-beta.34"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.6",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-                }
-            }
-        },
-        "web3-eth-personal": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
-            "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
-            "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
         "web3-net": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
-            "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
+            "version": "1.0.0-beta.37",
+            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.37.tgz",
+            "integrity": "sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==",
             "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-utils": "1.0.0-beta.34"
-            }
-        },
-        "web3-providers-http": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
-            "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
-            "requires": {
-                "web3-core-helpers": "1.0.0-beta.34",
-                "xhr2": "0.1.4"
-            }
-        },
-        "web3-providers-ipc": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
-            "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
-            "requires": {
-                "oboe": "2.1.3",
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
+                "web3-core": "1.0.0-beta.37",
+                "web3-core-method": "1.0.0-beta.37",
+                "web3-utils": "1.0.0-beta.37"
             },
             "dependencies": {
+                "bn.js": {
+                    "version": "4.11.6",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                },
                 "underscore": {
                     "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
                     "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-                }
-            }
-        },
-        "web3-providers-ws": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
-            "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
-            "requires": {
-                "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34",
-                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                },
+                "web3-core": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==",
+                    "requires": {
+                        "web3-core-helpers": "1.0.0-beta.37",
+                        "web3-core-method": "1.0.0-beta.37",
+                        "web3-core-requestmanager": "1.0.0-beta.37",
+                        "web3-utils": "1.0.0-beta.37"
+                    }
+                },
+                "web3-core-helpers": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==",
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-eth-iban": "1.0.0-beta.37",
+                        "web3-utils": "1.0.0-beta.37"
+                    }
+                },
+                "web3-core-method": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==",
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.37",
+                        "web3-core-promievent": "1.0.0-beta.37",
+                        "web3-core-subscriptions": "1.0.0-beta.37",
+                        "web3-utils": "1.0.0-beta.37"
+                    }
+                },
+                "web3-core-promievent": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==",
+                    "requires": {
+                        "any-promise": "1.3.0",
+                        "eventemitter3": "1.1.1"
+                    }
+                },
+                "web3-core-requestmanager": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==",
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.37",
+                        "web3-providers-http": "1.0.0-beta.37",
+                        "web3-providers-ipc": "1.0.0-beta.37",
+                        "web3-providers-ws": "1.0.0-beta.37"
+                    }
+                },
+                "web3-core-subscriptions": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==",
+                    "requires": {
+                        "eventemitter3": "1.1.1",
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.37"
+                    }
+                },
+                "web3-eth-iban": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==",
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "web3-utils": "1.0.0-beta.37"
+                    }
+                },
+                "web3-providers-http": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==",
+                    "requires": {
+                        "web3-core-helpers": "1.0.0-beta.37",
+                        "xhr2-cookies": "1.1.0"
+                    }
+                },
+                "web3-providers-ipc": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==",
+                    "requires": {
+                        "oboe": "2.1.3",
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.37"
+                    }
+                },
+                "web3-providers-ws": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==",
+                    "requires": {
+                        "underscore": "1.8.3",
+                        "web3-core-helpers": "1.0.0-beta.37",
+                        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.0.0-beta.37",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+                    "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "eth-lib": "0.1.27",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randomhex": "0.1.5",
+                        "underscore": "1.8.3",
+                        "utf8": "2.1.1"
+                    }
                 },
                 "websocket": {
                     "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
                     "requires": {
                         "debug": "^2.2.0",
                         "nan": "^2.3.3",
@@ -16358,21 +15766,10 @@
                 }
             }
         },
-        "web3-shh": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
-            "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
-            "requires": {
-                "web3-core": "1.0.0-beta.34",
-                "web3-core-method": "1.0.0-beta.34",
-                "web3-core-subscriptions": "1.0.0-beta.34",
-                "web3-net": "1.0.0-beta.34"
-            }
-        },
         "web3-utils": {
-            "version": "1.0.0-beta.34",
-            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
-            "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+            "version": "1.0.0-beta.37",
+            "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.37.tgz",
+            "integrity": "sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==",
             "requires": {
                 "bn.js": "4.11.6",
                 "eth-lib": "0.1.27",
@@ -16390,7 +15787,7 @@
                 },
                 "underscore": {
                     "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
                     "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 }
             }
@@ -17722,10 +17119,13 @@
                 "xhr-request": "^1.0.1"
             }
         },
-        "xhr2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-            "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
+        "xhr2-cookies": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+            "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+            "requires": {
+                "cookiejar": "^2.1.1"
+            }
         },
         "xml-name-validator": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
         "mkdirp": "^0.5.1",
         "semver": "^5.4.1",
         "wampy-cra": "^0.1.1",
-        "web3": "^1.0.0-beta.34",
+        "web3-net": "^1.0.0-beta.37",
+        "web3-utils": "^1.0.0-beta.37",
         "winston-uber": "^1.0.1",
         "yargs": "^12.0.2"
     },

--- a/src/components/wallet/modal/steps/Confirmation.js
+++ b/src/components/wallet/modal/steps/Confirmation.js
@@ -5,6 +5,7 @@ import {modals, currencyIcons} from './../../../../constants'
 
 const {clipboard } = window.electron
 const ETH_DENOM = 10 ** 18; //POW shorthand thanks to ES6
+const mainEtherscan = "https://etherscan.io/address";
 
 export default class Confirmation extends React.Component {
 
@@ -53,7 +54,7 @@ export default class Confirmation extends React.Component {
                     <div>
                         <strong className="info-label">to</strong>
                         <br/>
-                        <span className="info-address">{sendTo}</span>
+                        <span className="info-address"><a href={`${mainEtherscan}/${sendTo}`}>{sendTo}</a></span>
                     </div>
                     <div className="info-gas__container">
                         <strong className="info-label">GAS price</strong>

--- a/src/scss/settings/geth.scss
+++ b/src/scss/settings/geth.scss
@@ -10,6 +10,7 @@
 	button{
 		float: right;
 		margin-top: 10px;
+		transition: .5s all;
 	}
 
 	.section__flag,

--- a/src/scss/wallet/modal/steps/confirmation.scss
+++ b/src/scss/wallet/modal/steps/confirmation.scss
@@ -15,6 +15,7 @@
 
     .info-address{
     	line-height: 2em;
+        font-weight: 400;
     }
 
     .info-gas__container{

--- a/src/utils/getNetworkType.js
+++ b/src/utils/getNetworkType.js
@@ -1,0 +1,45 @@
+const axios = require('axios');
+
+const getNetworkType = async function(gethURL, net){
+
+    let genesis;
+
+    try{
+        const gethResult = await axios.post(gethURL, 
+                {
+                    "jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["earliest", false],"id":1
+                },
+                {
+                    timeout: 1000,
+                    headers: {'Content-Type': 'application/json'}
+                })
+
+        genesis = gethResult.data.result.hash;
+
+    } catch (error){
+        reject(error)
+    }
+
+    return new Promise((resolve, reject) => {
+        net.getId()
+            .then((_id) => {
+                let network = 'private'
+
+                if(_id == 1 && genesis === '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')
+                    network = 'main'
+                if(_id == 2 && genesis === '0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303')
+                    network = 'morden'
+                if(_id == 3 && genesis === '0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d')
+                    network = 'ropsten'
+                if(_id == 4 && genesis === '0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177')
+                    network = 'rinkeby'
+                if(_id == 5 && genesis === '0xa3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9')
+                    network = 'kovan'
+
+                resolve(network)
+            })
+            .catch((err) => reject(err));
+    })
+}
+
+module.exports = getNetworkType;


### PR DESCRIPTION
- Web3 dependency removed due to unstable `Scrypt` dependency
- Custom Geth Settings & Geth check mechanism improved
- Withdraw Confirmation improvements, users now can see the sender address on etherscan with a click.
- Custom `geth.gethNetworkType` function added, to avoid `web3-eth` lib usage for a single method.