### PR TITLE
Updated stats to include accepted/rejected subtasks

### DIFF
--- a/src/components/FooterMain.js
+++ b/src/components/FooterMain.js
@@ -219,7 +219,7 @@ export class FooterMain extends Component {
                                     <br/>
                                     <span>Attempted: {(stats.subtasks_computed) && (stats.subtasks_computed[1] + stats.subtasks_with_timeout[1] + stats.subtasks_with_errors[1])}</span>
                                     <br/>
-                                    <span>{stats.subtasks_with_errors && `${stats.subtasks_with_errors[1]} error | ${stats.subtasks_with_timeout[1]} timeout | ${stats.subtasks_accepted[1]} success` }</span>
+                                    <span>{stats.subtasks_with_errors && `${stats.subtasks_with_errors[1]} error | ${stats.subtasks_with_timeout && stats.subtasks_with_timeout[1]} timeout | ${stats.subtasks_accepted && stats.subtasks_accepted[1]} success` }</span>
                                 </div>
                                 : 
                                 <div className="status-node__loading">

--- a/src/components/FooterMain.js
+++ b/src/components/FooterMain.js
@@ -120,7 +120,7 @@ export default class FooterMain extends Component {
                                 <br/>
                                 <span>Attempted: {(stats && stats.subtasks_computed) && (stats.subtasks_computed[1] + stats.subtasks_with_timeout[1] + stats.subtasks_with_errors[1])}</span>
                                 <br/>
-                                <span>{(stats && stats.subtasks_with_errors) && `${stats.subtasks_with_errors[1]} error | ${stats.subtasks_with_timeout[1]} timeout | ${stats.subtasks_computed[1]} success` }</span>
+                                <span>{(stats && stats.subtasks_with_errors) && `${stats.subtasks_with_errors[1]} error | ${stats.subtasks_with_timeout[1]} timeout | ${stats.subtasks_accepted[1]} success` }</span>
                             </div>
                         </div>
                     </div>

--- a/src/components/__tests__/network/index.test.js
+++ b/src/components/__tests__/network/index.test.js
@@ -66,6 +66,8 @@ describe('<MainFragment />', () => {
                 stats: {
                     host_state: "",
                     subtasks_computed: [],
+                    subtasks_accepted: [],
+                    subtasks_rejected: [],
                     subtasks_with_timeout: [],
                     subtasks_with_errors: []
                 }

--- a/src/components/settings/Stats.js
+++ b/src/components/settings/Stats.js
@@ -27,9 +27,11 @@ export class Stats extends React.Component {
                     <div> 
                         <p>Tasks on network: {stats.in_network}</p>
                         <p>Supported tasks: {stats.supported}</p>
-                        <p>Computed subtask: {stats.subtasks_computed[1]}</p>
-                        <p>Subtask with errors: {stats.subtasks_with_errors[1]}</p>
-                        <p>Subtask with timeouts: {stats.subtasks_with_timeout[1]}</p>
+                        <p>Computed subtasks: {stats.subtasks_computed[1]}</p>
+                        <p>Accepted subtasks: {stats.subtasks_accepted[1]}</p>
+                        <p>Rejected subtasks: {stats.subtasks_rejected[1]}</p>
+                        <p>Subtasks with errors: {stats.subtasks_with_errors[1]}</p>
+                        <p>Subtasks with timeouts: {stats.subtasks_with_timeout[1]}</p>
                     </div>
                     :
                     <div className="no-stats">No available data.</div>


### PR DESCRIPTION
[#3697](https://github.com/golemfactory/golem/issues/3697)

This changes the 'success' value displayed in the main footer to show
subtasks which were accepted, rather than computed. Additionally, the
newly added stats fields are displayed in the 'Stats' page.